### PR TITLE
Arrange education and talks side-by-side

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,22 +222,41 @@
 
     <div class="section-divider"></div>
 
-    <!-- Education -->
+    <!-- Education and Invited Talks -->
     <section class="py-12 bg-white">
         <div class="container mx-auto px-6">
-            <h2 class="text-3xl font-bold text-center text-gray-800 mb-8">Education</h2>
-            <div class="max-w-3xl mx-auto space-y-6">
-                <div class="bg-gradient-to-r from-blue-50 to-purple-50 p-6 rounded-lg border-l-4 border-tech-blue">
-                    <h3 class="text-xl font-bold text-gray-800">Ph.D. in Computer Science</h3>
-                    <p class="text-gray-600">National Taiwan University</p>
+            <div class="grid md:grid-cols-2 gap-12">
+                <!-- Education -->
+                <div>
+                    <h2 class="text-3xl font-bold text-center text-gray-800 mb-8">Education</h2>
+                    <div class="space-y-6">
+                        <div class="bg-gradient-to-r from-blue-50 to-purple-50 p-6 rounded-lg border-l-4 border-tech-blue">
+                            <h3 class="text-xl font-bold text-gray-800">Ph.D. in Computer Science</h3>
+                            <p class="text-gray-600">National Taiwan University</p>
+                        </div>
+                        <div class="bg-gradient-to-r from-blue-50 to-purple-50 p-6 rounded-lg border-l-4 border-tech-blue">
+                            <h3 class="text-xl font-bold text-gray-800">M.S. in Computer Science</h3>
+                            <p class="text-gray-600">National Taiwan University</p>
+                        </div>
+                        <div class="bg-gradient-to-r from-blue-50 to-purple-50 p-6 rounded-lg border-l-4 border-tech-blue">
+                            <h3 class="text-xl font-bold text-gray-800">B.S. in Computer Science</h3>
+                            <p class="text-gray-600">National Tsing Hua University</p>
+                        </div>
+                    </div>
                 </div>
-                <div class="bg-gradient-to-r from-blue-50 to-purple-50 p-6 rounded-lg border-l-4 border-tech-blue">
-                    <h3 class="text-xl font-bold text-gray-800">M.S. in Computer Science</h3>
-                    <p class="text-gray-600">National Taiwan University</p>
-                </div>
-                <div class="bg-gradient-to-r from-blue-50 to-purple-50 p-6 rounded-lg border-l-4 border-tech-blue">
-                    <h3 class="text-xl font-bold text-gray-800">B.S. in Computer Science</h3>
-                    <p class="text-gray-600">National Tsing Hua University</p>
+                <!-- Selected Invited Talks -->
+                <div>
+                    <h2 class="text-3xl font-bold text-center text-gray-800 mb-8">Selected Invited Talks</h2>
+                    <div class="space-y-6">
+                        <div class="bg-gradient-to-r from-blue-50 to-purple-50 p-6 rounded-lg">
+                            <h3 class="font-bold text-gray-800 mb-2">AI Transformation in Enterprise</h3>
+                            <p class="text-gray-600 text-sm">National Taiwan University • 2023</p>
+                        </div>
+                        <div class="bg-gradient-to-r from-blue-50 to-purple-50 p-6 rounded-lg">
+                            <h3 class="font-bold text-gray-800 mb-2">Generative AI in Production</h3>
+                            <p class="text-gray-600 text-sm">National Tsing Hua University • 2023</p>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -484,25 +503,6 @@
                             <div class="text-gray-600 text-sm">Research Areas</div>
                         </div>
                     </div>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <div class="section-divider"></div>
-
-    <!-- Invited Talks -->
-    <section class="py-12 bg-white">
-        <div class="container mx-auto px-6">
-            <h2 class="text-3xl font-bold text-center text-gray-800 mb-8">Selected Invited Talks</h2>
-            <div class="max-w-4xl mx-auto grid md:grid-cols-2 gap-6">
-                <div class="bg-gradient-to-r from-blue-50 to-purple-50 p-6 rounded-lg">
-                    <h3 class="font-bold text-gray-800 mb-2">AI Transformation in Enterprise</h3>
-                    <p class="text-gray-600 text-sm">National Taiwan University • 2023</p>
-                </div>
-                <div class="bg-gradient-to-r from-blue-50 to-purple-50 p-6 rounded-lg">
-                    <h3 class="font-bold text-gray-800 mb-2">Generative AI in Production</h3>
-                    <p class="text-gray-600 text-sm">National Tsing Hua University • 2023</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Place Education and Selected Invited Talks blocks in a single two-column section so they display side by side.

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b0656fa3ec832ea97a1438076e923a