### PR TITLE
Add NTHU talk link and external link icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,13 +249,23 @@
                     <h2 class="text-3xl font-bold text-center text-gray-800 mb-8">Selected Invited Talks</h2>
                     <div class="space-y-6">
                         <a href="https://csie.ntu.edu.tw/zh_tw/Announcements/Announcement7/%5B2024-09-20%5D%C2%A0Dr-Yu-Kai-Kyle-Huang%C2%A0-MediaTek-%E2%80%9DA-Journey-through-Al-Transformation-in-the-Enterprise%E2%80%9D-25412110" target="_blank" class="bg-gradient-to-r from-blue-50 to-purple-50 p-6 rounded-lg block">
-                            <h3 class="font-bold text-gray-800 mb-2">AI Transformation in Enterprise</h3>
+                            <h3 class="font-bold text-gray-800 mb-2 flex items-center">AI Transformation in Enterprise
+                                <svg class="w-4 h-4 ml-2" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M3 5a2 2 0 012-2h3a1 1 0 110 2H5v10h10v-3a1 1 0 112 0v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5z" clip-rule="evenodd"></path>
+                                    <path d="M9 3a1 1 0 000 2h3.586l-6.293 6.293a1 1 0 101.414 1.414L14 6.414V10a1 1 0 102 0V3H9z"></path>
+                                </svg>
+                            </h3>
                             <p class="text-gray-600 text-sm">National Taiwan University • 2023</p>
                         </a>
-                        <div class="bg-gradient-to-r from-blue-50 to-purple-50 p-6 rounded-lg">
-                            <h3 class="font-bold text-gray-800 mb-2">Generative AI in Production</h3>
+                        <a href="https://isa.site.nthu.edu.tw/p/406-1182-273873,r2619.php?Lang=zh-tw" target="_blank" class="bg-gradient-to-r from-blue-50 to-purple-50 p-6 rounded-lg block">
+                            <h3 class="font-bold text-gray-800 mb-2 flex items-center">Generative AI in Production
+                                <svg class="w-4 h-4 ml-2" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M3 5a2 2 0 012-2h3a1 1 0 110 2H5v10h10v-3a1 1 0 112 0v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5z" clip-rule="evenodd"></path>
+                                    <path d="M9 3a1 1 0 000 2h3.586l-6.293 6.293a1 1 0 101.414 1.414L14 6.414V10a1 1 0 102 0V3H9z"></path>
+                                </svg>
+                            </h3>
                             <p class="text-gray-600 text-sm">National Tsing Hua University • 2023</p>
-                        </div>
+                        </a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Link "Generative AI in Production" invited talk to NTHU event page
- Add external link icons to invited talk entries for better visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a7dcac00832e8c8a9712422931e0