### PR TITLE
Align typography for education and invited talks

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,12 +249,12 @@
                     <h2 class="text-3xl font-bold text-center text-gray-800 mb-8">Selected Invited Talks</h2>
                     <div class="space-y-6">
                         <a href="https://csie.ntu.edu.tw/zh_tw/Announcements/Announcement7/%5B2024-09-20%5D%C2%A0Dr-Yu-Kai-Kyle-Huang%C2%A0-MediaTek-%E2%80%9DA-Journey-through-Al-Transformation-in-the-Enterprise%E2%80%9D-25412110" target="_blank" class="bg-gradient-to-r from-blue-50 to-purple-50 p-6 rounded-lg block">
-                            <h3 class="font-bold text-gray-800 mb-2">AI Transformation in Enterprise</h3>
-                            <p class="text-gray-600 text-sm">National Taiwan University • 2023</p>
+                            <h3 class="text-xl font-bold text-gray-800">AI Transformation in Enterprise</h3>
+                            <p class="text-gray-600">National Taiwan University • 2023</p>
                         </a>
                         <div class="bg-gradient-to-r from-blue-50 to-purple-50 p-6 rounded-lg">
-                            <h3 class="font-bold text-gray-800 mb-2">Generative AI in Production</h3>
-                            <p class="text-gray-600 text-sm">National Tsing Hua University • 2023</p>
+                            <h3 class="text-xl font-bold text-gray-800">Generative AI in Production</h3>
+                            <p class="text-gray-600">National Tsing Hua University • 2023</p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Align fonts between Education and Selected Invited Talks sections for consistent appearance.

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden from npm registry)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a8198098832eb86c549a2763f1c2