### PR TITLE
Fix missing security attributes on external talk links

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,7 +248,7 @@
                 <div>
                     <h2 class="text-3xl font-bold text-center text-gray-800 mb-8">Selected Invited Talks</h2>
                     <div class="space-y-6">
-                        <a href="https://csie.ntu.edu.tw/zh_tw/Announcements/Announcement7/%5B2024-09-20%5D%C2%A0Dr-Yu-Kai-Kyle-Huang%C2%A0-MediaTek-%E2%80%9DA-Journey-through-Al-Transformation-in-the-Enterprise%E2%80%9D-25412110" target="_blank" class="bg-gradient-to-r from-blue-50 to-purple-50 p-6 rounded-lg block">
+                        <a href="https://csie.ntu.edu.tw/zh_tw/Announcements/Announcement7/%5B2024-09-20%5D%C2%A0Dr-Yu-Kai-Kyle-Huang%C2%A0-MediaTek-%E2%80%9DA-Journey-through-Al-Transformation-in-the-Enterprise%E2%80%9D-25412110" target="_blank" rel="noopener noreferrer" class="bg-gradient-to-r from-blue-50 to-purple-50 p-6 rounded-lg block">
                             <h3 class="font-bold text-gray-800 mb-2 flex items-center">AI Transformation in Enterprise
                                 <svg class="w-4 h-4 ml-2" fill="currentColor" viewBox="0 0 20 20">
                                     <path fill-rule="evenodd" d="M3 5a2 2 0 012-2h3a1 1 0 110 2H5v10h10v-3a1 1 0 112 0v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5z" clip-rule="evenodd"></path>
@@ -257,7 +257,7 @@
                             </h3>
                             <p class="text-gray-600 text-sm">National Taiwan University • 2023</p>
                         </a>
-                        <a href="https://isa.site.nthu.edu.tw/p/406-1182-273873,r2619.php?Lang=zh-tw" target="_blank" class="bg-gradient-to-r from-blue-50 to-purple-50 p-6 rounded-lg block">
+                        <a href="https://isa.site.nthu.edu.tw/p/406-1182-273873,r2619.php?Lang=zh-tw" target="_blank" rel="noopener noreferrer" class="bg-gradient-to-r from-blue-50 to-purple-50 p-6 rounded-lg block">
                             <h3 class="font-bold text-gray-800 mb-2 flex items-center">Generative AI in Production
                                 <svg class="w-4 h-4 ml-2" fill="currentColor" viewBox="0 0 20 20">
                                     <path fill-rule="evenodd" d="M3 5a2 2 0 012-2h3a1 1 0 110 2H5v10h10v-3a1 1 0 112 0v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5z" clip-rule="evenodd"></path>


### PR DESCRIPTION
## Summary
- Add `rel="noopener noreferrer"` to "Selected Invited Talks" external links to prevent reverse-tabnabbing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ab671fd8832eaf43f336f1f4e7a3