### PR TITLE
Add blog link with icon to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,14 @@
                     </svg>
                     https://yukai.ai
                 </a>
+                <a href="https://podcasts.apple.com/tw/podcast/%E7%A7%91%E5%AD%B8%E5%A5%BD%E5%A5%BD%E8%81%BD/id1812447277" target="_blank" rel="noopener noreferrer" class="flex items-center hover:text-gray-900 transition-colors cursor-pointer">
+                    <span class="text-xl mr-2">🎧</span>
+                    科學好好聽 Podcast
+                </a>
+                <a href="https://vocus.cc/salon/kyle" target="_blank" rel="noopener noreferrer" class="flex items-center hover:text-gray-900 transition-colors cursor-pointer">
+                    <span class="text-xl mr-2">📝</span>
+                    Vocus Blog
+                </a>
             </div>
         </div>
     </header>


### PR DESCRIPTION
## Summary
- Add Vocus blog link with memo emoji to contact section

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b67bdd00832eaa16a255910855f4